### PR TITLE
remove unnecessary function to abstract class

### DIFF
--- a/Src/AbstractValidation.php
+++ b/Src/AbstractValidation.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace src;
+
+use enums\ValidationAttributes;
+
+abstract class AbstractValidation
+{
+  protected static array $validation = [];
+
+  protected static function push(string $value): void
+  {
+    self::$validation[] = $value;
+  }
+
+  protected static function reset(): void
+  {
+    self::$validation = [];
+  }
+
+  protected static function checkAndSetRequired(bool $required): void
+  {
+    if ($required) {
+      self::push(ValidationAttributes::REQUIRED->value);
+
+      return;
+    }
+
+    self::push(ValidationAttributes::NULLABLE->value);
+
+    return;
+  }
+
+  protected static function setMin(int $min): void
+  {
+    self::push(ValidationAttributes::MIN->value . $min);
+
+    return;
+  }
+
+  protected static function setMax(int $max): void
+  {
+    self::push(ValidationAttributes::MAX->value . $max);
+
+    return;
+  }
+
+  protected static function setUnique(string $unique): void
+  {
+    self::push(ValidationAttributes::UNIQUE->value . $unique);
+
+    return;
+  }
+
+  protected static function setAddationalRules($rules): void
+  {
+    foreach ($rules as $rule) {
+      self::push($rule);
+    }
+
+    return;
+  }
+}

--- a/Src/ValidationHelper.php
+++ b/Src/ValidationHelper.php
@@ -5,64 +5,9 @@ declare(strict_types=1);
 namespace src;
 
 use enums\DataTypes;
-use enums\ValidationAttributes;
 
-class ValidationHelper
+class ValidationHelper extends AbstractValidation
 {
-  private static array $validation = [];
-
-  protected static function push(string $value): void
-  {
-    self::$validation[] = $value;
-  }
-
-  protected static function reset(): void
-  {
-    self::$validation = [];
-  }
-
-  protected static function checkAndSetRequired(bool $required): void
-  {
-    if ($required) {
-      self::push(ValidationAttributes::REQUIRED->value);
-
-      return;
-    }
-
-    self::push(ValidationAttributes::NULLABLE->value);
-
-    return;
-  }
-
-  protected static function setMin(int $min): void
-  {
-    self::push(ValidationAttributes::MIN->value . $min);
-
-    return;
-  }
-
-  protected static function setMax(int $max): void
-  {
-    self::push(ValidationAttributes::MAX->value . $max);
-
-    return;
-  }
-
-  protected static function setUnique(string $unique): void
-  {
-    self::push(ValidationAttributes::UNIQUE->value . $unique);
-
-    return;
-  }
-
-  protected static function setAddationalRules($rules): void
-  {
-    foreach ($rules as $rule) {
-      self::push($rule);
-    }
-
-    return;
-  }
 
   public static function validateString(
     bool $required,


### PR DESCRIPTION
To remove clutter from the validation helper. i have extracted the function that are not meant to be called by people to a abstract class